### PR TITLE
Add APK install, keyboard text input, and ADB terminal features

### DIFF
--- a/src/adb.ts
+++ b/src/adb.ts
@@ -1,0 +1,111 @@
+import { exec, spawn } from 'node:child_process';
+import { createLogger } from './logger';
+
+const logger = createLogger();
+
+const ADB_PORT = 5555;
+
+const execAsync = (cmd: string): Promise<string> =>
+    new Promise((resolve, reject) => {
+        exec(cmd, (error, stdout, stderr) => {
+            if (error) {
+                reject(new Error(stderr || error.message));
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+
+/**
+ * Returns true if the `adb` binary is available on the host machine.
+ */
+export const isAdbAvailable = (): Promise<boolean> =>
+    execAsync('adb version').then(() => true).catch(() => false);
+
+/**
+ * Connects ADB to the TV at the given IP address on the default ADB port (5555).
+ */
+export const adbConnect = (ip: string): Promise<void> => {
+    logger.info(`ADB connecting to ${ip}:${ADB_PORT}...`);
+    return execAsync(`adb connect ${ip}:${ADB_PORT}`).then(out => {
+        logger.debug('adb connect output:', out.trim());
+        if (out.includes('failed') || out.includes('unable')) {
+            throw new Error(`ADB connect failed: ${out.trim()}`);
+        }
+    });
+};
+
+/**
+ * Disconnects ADB from the TV at the given IP address.
+ */
+export const adbDisconnect = (ip: string): Promise<void> => {
+    logger.info(`ADB disconnecting from ${ip}:${ADB_PORT}...`);
+    return execAsync(`adb disconnect ${ip}:${ADB_PORT}`).then(out => {
+        logger.debug('adb disconnect output:', out.trim());
+    }).catch(() => {
+        // Ignore disconnect errors — the session may already be gone
+    });
+};
+
+/**
+ * Installs an APK on the TV via ADB over the network.
+ *
+ * Requires `adb` to be installed on the host machine and Developer Mode /
+ * USB Debugging to be enabled on the TV.
+ *
+ * @param ip      TV IP address
+ * @param apkPath Absolute or relative path to the APK file on the host
+ */
+export const installApk = async (ip: string, apkPath: string): Promise<void> => {
+    if (!(await isAdbAvailable())) {
+        throw new Error('adb is not installed or not in PATH');
+    }
+
+    await adbConnect(ip);
+
+    logger.info(`Installing APK: ${apkPath}`);
+    try {
+        const out = await execAsync(`adb -s ${ip}:${ADB_PORT} install -r "${apkPath}"`);
+        logger.debug('adb install output:', out.trim());
+        if (!out.includes('Success')) {
+            throw new Error(`APK install failed: ${out.trim()}`);
+        }
+    } finally {
+        await adbDisconnect(ip);
+    }
+};
+
+/**
+ * Launches an interactive ADB shell session on the TV, bridged to the local
+ * terminal's stdin/stdout/stderr.  The returned promise resolves when the
+ * shell session exits.
+ *
+ * Requires `adb` to be installed on the host machine and Developer Mode /
+ * USB Debugging to be enabled on the TV.
+ *
+ * @param ip TV IP address
+ */
+export const launchAdbShell = async (ip: string): Promise<void> => {
+    if (!(await isAdbAvailable())) {
+        throw new Error('adb is not installed or not in PATH');
+    }
+
+    await adbConnect(ip);
+
+    return new Promise((resolve, reject) => {
+        logger.info('Launching ADB shell...');
+        const proc = spawn('adb', ['-s', `${ip}:${ADB_PORT}`, 'shell'], {
+            stdio: 'inherit'
+        });
+
+        proc.on('error', async err => {
+            await adbDisconnect(ip);
+            reject(err);
+        });
+
+        proc.on('close', async () => {
+            await adbDisconnect(ip);
+            resolve();
+        });
+    });
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,5 @@
 import { clearScreenDown, createInterface, emitKeypressEvents, moveCursor } from 'node:readline';
+import { installApk, isAdbAvailable, launchAdbShell } from './adb';
 import { getAwakeSamsungDevices, getLastConnectedDevice } from './discovery';
 import { Keys } from './keys';
 import type { SamsungDevice } from './models';
@@ -40,13 +41,15 @@ const KEYS_MAP: Record<string, keyof typeof Keys> = {
 
 const cyan = (message: string): string => process.stdout.isTTY ? `\x1b[36m${message}\x1b[0m` : message;
 const gray = (message: string): string => process.stdout.isTTY ? `\x1b[90m${message}\x1b[0m` : message;
+const green = (message: string): string => process.stdout.isTTY ? `\x1b[32m${message}\x1b[0m` : message;
 const magenta = (message: string): string => process.stdout.isTTY ? `\x1b[35m${message}\x1b[0m` : message;
+const red = (message: string): string => process.stdout.isTTY ? `\x1b[31m${message}\x1b[0m` : message;
 const yellow = (message: string): string => process.stdout.isTTY ? `\x1b[33m${message}\x1b[0m` : message;
 
 const deviceLabel = (device: SamsungDevice): string =>
     `${device.friendlyName ?? 'Unknown'} ${gray(`(ip: ${device.ip}, mac: ${device.mac})`)}`;
 
-const displayHelp = () => {
+const displayHelp = (adbAvailable: boolean) => {
     console.log(cyan('Usage'));
     console.log(`  Arrows (${yellow('←/↑/↓/→')})`);
     console.log(`  Channel (${yellow('w/s')})`);
@@ -56,7 +59,15 @@ const displayHelp = () => {
     console.log(`  Play (${yellow('p')})`);
     console.log(`  Power (${yellow('q')})`);
     console.log(`  Return (${yellow('Backspace')})`);
-    console.log(`  Volume (${yellow('+/-')})\n`);
+    console.log(`  Send text (${yellow('t')})`);
+    console.log(`  Volume (${yellow('+/-')})`);
+    if (adbAvailable) {
+        console.log(`  Install APK (${yellow('i')})`);
+        console.log(`  Terminal session (${yellow('T')})`);
+    } else {
+        console.log(yellow('  [ADB not found — install/terminal features disabled]'));
+    }
+    console.log('');
 };
 
 const askQuestion = (question: string): Promise<string> =>
@@ -83,6 +94,20 @@ const chooseDevice = async (devices: SamsungDevice[]): Promise<number> => {
     return Number(await askQuestion(question));
 };
 
+/** Suspend raw mode, run an async operation, then restore raw mode. */
+const withCookedMode = async (fn: () => Promise<void>): Promise<void> => {
+    if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+    }
+    try {
+        await fn();
+    } finally {
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+        }
+    }
+};
+
 (async () => {
     if (process.argv.includes('--version') || process.argv.includes('-v')) {
         console.log(process.env.npm_package_version);
@@ -90,7 +115,9 @@ const chooseDevice = async (devices: SamsungDevice[]): Promise<number> => {
     }
 
     console.log(magenta('[SamsungTvRemote]\n'));
-    displayHelp();
+
+    const adbAvailable = await isAdbAvailable();
+    displayHelp(adbAvailable);
 
     try {
         let selectedDevice: SamsungDevice | undefined;
@@ -137,7 +164,76 @@ const chooseDevice = async (devices: SamsungDevice[]): Promise<number> => {
         if (process.stdin.isTTY) {
             process.stdin.setRawMode(true); // allow raw-mode to catch character by character
         }
+
+        // Track whether we are already handling a modal prompt so we don't
+        // stack multiple overlapping interactions.
+        let busy = false;
+
         process.stdin.on('keypress', async (_str: string, key: KeyPressed) => {
+            if (busy) return;
+
+            // --- Send text to TV ---
+            if (key.name === 't' && !key.ctrl && !key.meta && !key.shift) {
+                busy = true;
+                await withCookedMode(async () => {
+                    const text = await askQuestion(cyan('> Enter text to send: '));
+                    if (text) {
+                        console.log(`${cyan('>')} sending text...`, gray(JSON.stringify(text)));
+                        await remote.sendText(text);
+                        setTimeout(() => {
+                            moveCursor(process.stdout, 0, -1);
+                            clearScreenDown(process.stdout);
+                        }, 250);
+                    }
+                });
+                busy = false;
+                return;
+            }
+
+            // --- Install APK via ADB ---
+            if (key.name === 'i' && !key.ctrl && !key.meta && !key.shift && adbAvailable) {
+                busy = true;
+                await withCookedMode(async () => {
+                    const apkPath = await askQuestion(cyan('> Path to APK file: '));
+                    if (apkPath) {
+                        console.log(`${cyan('>')} installing APK...`, gray(apkPath));
+                        try {
+                            await installApk(selectedDevice!.ip, apkPath);
+                            console.log(green('> APK installed successfully'));
+                        } catch (err: unknown) {
+                            console.log(red(`> APK install failed: ${(err as Error).message}`));
+                        }
+                        setTimeout(() => {
+                            moveCursor(process.stdout, 0, -1);
+                            clearScreenDown(process.stdout);
+                        }, 1500);
+                    }
+                });
+                busy = false;
+                return;
+            }
+
+            // --- ADB terminal session (Shift+T) ---
+            if (key.name === 't' && key.shift && adbAvailable) {
+                busy = true;
+                console.log(cyan('> Launching ADB shell — type "exit" or press Ctrl+D to return\n'));
+                if (process.stdin.isTTY) {
+                    process.stdin.setRawMode(false);
+                }
+                try {
+                    await launchAdbShell(selectedDevice!.ip);
+                } catch (err: unknown) {
+                    console.log(red(`> ADB shell failed: ${(err as Error).message}`));
+                }
+                console.log(cyan('\n> Back in remote control mode'));
+                if (process.stdin.isTTY) {
+                    process.stdin.setRawMode(true);
+                }
+                busy = false;
+                return;
+            }
+
+            // --- Standard remote-control keys ---
             if (key.sequence in KEYS_MAP) {
                 console.log(`${cyan('>')} sending...`, gray(KEYS_MAP[key.sequence]));
                 await remote.sendKey(KEYS_MAP[key.sequence]);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -217,19 +217,18 @@ const withCookedMode = async (fn: () => Promise<void>): Promise<void> => {
             if (key.name === 't' && key.shift && adbAvailable) {
                 busy = true;
                 console.log(cyan('> Launching ADB shell — type "exit" or press Ctrl+D to return\n'));
-                if (process.stdin.isTTY) {
-                    process.stdin.setRawMode(false);
-                }
                 try {
-                    await launchAdbShell(selectedDevice!.ip);
-                } catch (err: unknown) {
-                    console.log(red(`> ADB shell failed: ${(err as Error).message}`));
+                    await withCookedMode(async () => {
+                        try {
+                            await launchAdbShell(selectedDevice!.ip);
+                        } catch (err: unknown) {
+                            console.log(red(`> ADB shell failed: ${(err as Error).message}`));
+                        }
+                    });
+                } finally {
+                    console.log(cyan('\n> Back in remote control mode'));
+                    busy = false;
                 }
-                console.log(cyan('\n> Back in remote control mode'));
-                if (process.stdin.isTTY) {
-                    process.stdin.setRawMode(true);
-                }
-                busy = false;
                 return;
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
  *  https://github.com/Badisi/samsung-tv-remote
  */
 
+export { installApk, isAdbAvailable, launchAdbShell } from './adb';
 export { getAwakeSamsungDevices, getLastConnectedDevice } from './discovery';
 export { Keys } from './keys';
 export type { SamsungDevice, SamsungTvRemoteOptions } from './models';

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -98,6 +98,36 @@ export class SamsungTvRemote {
     }
 
     /**
+     * Sends a text string to the TV (e.g. to fill a search box).
+     *
+     * The TV must have a text input field focused for this to take effect.
+     *
+     * @async
+     * @param {string} text The text to send
+     * @returns {Promise<void>} A void promise
+     */
+    public async sendText(text: string): Promise<void> {
+        if (text) {
+            await this.#connectToTV();
+
+            logger.info('⌨️ Sending text...', text);
+            this.#webSocket?.send(
+                JSON.stringify({
+                    method: 'ms.remote.control',
+                    params: {
+                        Cmd: 'Click',
+                        DataOfCmd: Buffer.from(text).toString('base64'),
+                        Option: false,
+                        TypeOfRemote: 'SendInputString'
+                    }
+                })
+            );
+
+            await this.#delay(this.#options.keysDelay);
+        }
+    }
+
+    /**
      * Turns the TV on or awaken it from sleep mode (also called WoL - Wake-on-LAN).
      *
      * The mac address option is required in this case.


### PR DESCRIPTION
- remote.ts: add sendText() using Samsung's SendInputString WebSocket protocol
- adb.ts: new module with isAdbAvailable, adbConnect/Disconnect, installApk, launchAdbShell
- cli.ts: press 't' to type text, 'i' to install an APK, 'T' (Shift+T) to open an ADB shell session; ADB features are gracefully hidden when adb is not installed
- index.ts: export new ADB utilities for library consumers

https://claude.ai/code/session_012ytS8P5iL1ZY7t5fVrrACr