### PR TITLE
fix(cli): bin entrypoint imports library instead of CLI

### DIFF
--- a/bin/samsung-tv-remote
+++ b/bin/samsung-tv-remote
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-import '../index.mjs';
+import '../cli.mjs';


### PR DESCRIPTION
## Problem

Running `npx samsung-tv-remote` (documented under **Command line tool** in the README) no longer shows the interactive remote — it runs, prints nothing, and exits immediately.

## Cause

`bin/samsung-tv-remote` imports the **library** entry instead of the **CLI** entry:

```js
#!/usr/bin/env node

import '../index.mjs';   // only re-exports functions → does nothing
```

`index.mjs` just re-exports `SamsungTvRemote`, `Keys`, etc., so importing it has no side effect and the process exits.

This regressed in **32b446f** (*"refactor: improvements - replaced tsc with tsdown - replaced node with tsx"*), first published in **3.0.7**. The previous launcher correctly pointed at the CLI (`require('../cli.js')`). The CLI itself is unaffected and is still built and shipped as `cli.mjs` / `cli.cjs` (`tsdown.config.ts` builds both `src/index.ts` and `src/cli.ts`) — only the bin points at the wrong one.

## Fix

Point the bin back at the CLI entry:

```diff
-import '../index.mjs';
+import '../cli.mjs';
```

## Verification

```sh
node dist/bin/samsung-tv-remote   # now launches the interactive remote
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)